### PR TITLE
Proofread. Update with minor edits 2016-10-07

### DIFF
--- a/source/blog_articles/2016-10-07-the-complexity-edifice.html.markdown
+++ b/source/blog_articles/2016-10-07-the-complexity-edifice.html.markdown
@@ -15,7 +15,7 @@ I assumed getting to safe green shores with this PremiumPlus upgrade button migh
 
 Some [solo googling](http://stackoverflow.com/a/20101117/316729) had showed me that there should be some simple fixes for mixing FactoryGirl and STI; although I was still nervous about the fairylight connections between all these different factories that required special tweaking to behave like objects in production.  I knew we had a potential fix for the insecure [current_user](https://github.com/plataformatec/devise/issues/4317#issuecomment-251667866), and a possible alternate for [mocking Stripe](https://github.com/rebelidealist/stripe-ruby-mock), but all of these were arguably distractions while we were still trying to get the tests green.
 
-We'd manage to avoid aggravating the Cuke usage of factories by adjusting the step that created a premium member like so:
+We'd managed to avoid aggravating the Cuke usage of factories by adjusting the step that created a premium member like so:
 
 ```rb
 Given /^I am logged in as( a premium)? user with (?:name "([^"]*)", )?email "([^"]*)", with password "([^"]*)"$/ do |premium, name, email, password|
@@ -33,11 +33,11 @@ Given /^I am logged in as( a premium)? user with (?:name "([^"]*)", )?email "([^
 end
 ```
 
-Now I still wasn't completely happy with this, but I was feeling a little suspicious of factories and so just creating the Subscription and PaymentSource the objects directly felt a little safer.  Of course, the entire acceptance test was slightly compromised by reaching in to the database anyway.  A cleaner test might have gone through the entire sign up process for premium, before trying a premium plus upgrade.  The trade off here is running time, and the question is can we get the database into a state that corresponds to what would have been the case if a full premium signup had happened.
+Now I still wasn't completely happy with this, but I was feeling a little suspicious of factories and so just creating the Subscription and PaymentSource objects directly felt a little safer.  Of course, the entire acceptance test was slightly compromised by reaching in to the database anyway.  A cleaner test might have gone through the entire sign up process for premium, before trying a premium plus upgrade.  The trade off here is running time, and the question is can we get the database into a state that corresponds to what would have been the case if a full premium signup had happened.
 
 Factories in cukes had bitten us hard last week.  In the LocalSupport project we avoided every scenario having to repeat sign in by reaching in to the capybara session cookies.  Here in WebsiteOne we were stepping directly through the sign in operation, but creating the users with factories.  In LocalSupport we create the users with simple object creation.  I'd been burnt in the early days by Rails fixtures, to which factories were supposedly the solution, although apparently even [fixtures are being rehabilitated](http://chriskottom.com/blog/2014/11/fixing-fixtures/).  The right tool is all dependent on context of course :-)
 
-I think the issue here is partly the general one of descriptions of encapsulated things.  We see it in the naming of methods, the naming of steps; it's all about the extent to which the details of what happen under the hood are inferable from the description.  So for example in the above code the step is something like `Given I am logged in as a premium user with name "John", email "john@john.com", with password "asdf1234"`  (and yes, that password should be defaulted), and this is reasonable, we would expect to have a logged in user who is signed up for premium.  Then inside the step we have things like `Premium.create(user: @user, started_at: Time.now)` which it creates a premium subscription for a user starting now.  Maybe it would be better as `Subscription::Premium` but still, my fear is that `FactoryGirl.create(:user, first_name: name, email: email, password: password, password_confirmation: password)` is hiding a lot of complexity from me.  It happens to also create a G+ authentication and a Karma object.
+I think the issue here is partly the general one of descriptions of encapsulated things.  We see it in the naming of methods, the naming of steps; it's all about the extent to which the details of what happen under the hood are inferable from the description.  So for example in the above code the step is something like `Given I am logged in as a premium user with name "John", email "john@john.com", with password "asdf1234"`  (and yes, that password should be defaulted), and this is reasonable, we would expect to have a logged in user who is signed up for premium.  Then inside the step we have things like `Premium.create(user: @user, started_at: Time.now)` which creates a premium subscription for a user starting now.  Maybe it would be better as `Subscription::Premium` but still, my fear is that `FactoryGirl.create(:user, first_name: name, email: email, password: password, password_confirmation: password)` is hiding a lot of complexity from me.  It happens to also create a G+ authentication and a Karma object.
 
 I guess the solution there is better names for our factories, rather than throwing out factories themselves.  The creation of the Karma object should just be removed from the factory, but we could call this factory :user_authenticated_with_gplus to make things a little more transparent.  I'm still uncomfortable about features and specs sharing factories, but I'm also not entirely clear if we can separate them.  We're using the `factory_girl_rails` and so FactoryGirl appears to be available as a singleton throughout our specs and cucumber steps, hmmm.
 
@@ -104,12 +104,13 @@ but we were also getting an acceptance fail on upgrade from basic to premium, an
 
 ![stripe pop up](https://www.dropbox.com/s/h5zv1ge3rhrbgly/Screenshot%202016-10-07%2009.45.13.png?dl=1)
 
-It's the thing that I speculate that most people don't test in their acceptance tests because sandboxing it effectively requires custom work in puffing billy that I've blogged about before.  Well, who knows, maybe everyones doing it.  I've often made the mistake of thinking we're doing something clever or hard, only to find lots of others are doing it and finding it trivial :-)
+It's the thing that I speculate that most people don't test in their acceptance tests because sandboxing it effectively requires custom work in puffing billy that I've blogged about before.  Well, who knows, maybe everyone's doing it.  I've often made the mistake of thinking we're doing something clever or hard, only to find lots of others are doing it and finding it trivial :-)
 
 Michael's faulty modem sound alert was going off, and my post-operative knee was in quite a lot of pain.  I suggested a "pair off".  We should separate, work on this individually and then compare notes at the scrum.  I'm bedridden this week, and I find the single laptop (I'm usually docked to three monitors) very constraining in a pairing session.  We separated and prodded at the system separately.  Michael was in bye bug confirming that the dialogue really didn't pop up in the test environment:
 
 ```
-*** Capybara::Poltergeist::ObsoleteNode Exception: The element you are trying to interact with is either not part of the DOM, or is not currently visible on the page (perhaps display: none is set). It's possible the element has been replaced by another element and you meant to interact with the new element. If so you need to do a new 'find' in order to get a reference to the new element.```
+*** Capybara::Poltergeist::ObsoleteNode Exception: The element you are trying to interact with is either not part of the DOM, or is not currently visible on the page (perhaps display: none is set). It's possible the element has been replaced by another element and you meant to interact with the new element. If so you need to do a new 'find' in order to get a reference to the new element.
+```
 
 I was looking at the traces in the sandbox.  I had rolled back to our stable develop branch and it was clear to me that Stripe was rejecting the request from the headless browser to get the info to display the popup (which involves a request to the Stripe servers):
 
@@ -146,7 +147,7 @@ The VCR cache no longer leaked, the tests passed and it was now a simple fix to 
 It was satisfying to go green, but there are some things here that I don't think I can push off to refactoring tickets:
 
 1) we need some sad paths for upgrade failure 
-2) we've got to look careful at Demeter violations in the way we use the Stripe API and our own domain objects
+2) we've got to look carefully at Demeter violations in the way we use the Stripe API and our own domain objects
 3) patching develop with the VCR config fix
 
 In the scrum I was talking about Donald Norman's Design of Everyday Things, in which he laments how people blame themselves for not understanding poorly designed things.  Git, Stripe, Rails, Acceptance testing.  There's some real complexity there.  I'm not saying they are poorly designed, but the edifice of concepts that someone needs to understand to work with our acceptance tests ... maybe the problem is not the tools, but the way we are building on top of them?


### PR DESCRIPTION
It _is_ comprehensible in blog form. Nice job.
 
I moved the backtics from the end of line 112 to 113 on a new line, to fix the code formatting. However, rich diff wasn't showing it quite right at first. If you look at it in "view" or the split view, it should be more clear.
 
When I clicked back to rich diff, it was accurate, but might be confusing; large red blocks and green blocks only from the move of the backtics to the new line.